### PR TITLE
fix: pages referencing incorrect videos

### DIFF
--- a/exercises/01.exercise-navigation/01.solution.first-step/README.mdx
+++ b/exercises/01.exercise-navigation/01.solution.first-step/README.mdx
@@ -1,6 +1,6 @@
 # First Exercise Step
 
-<EpicVideo url="https://www.epicweb.dev/tutorials/learn-how-to-use-the-epic-workshop-app~kfmou/app-qnd9s/your-first-exercise-step-problem-winqy" />
+<EpicVideo url="https://www.epicweb.dev/tutorials/learn-how-to-use-the-epic-workshop-app~kfmou/app-qnd9s/your-first-exercise-step-solution-lypql" />
 
 👨‍💼 Great job! You've made it to the solution portion of the first exercise step!
 On this page, you'll often find a video, diagrams, and code examples, and other

--- a/exercises/01.exercise-navigation/02.problem.multi-step/README.mdx
+++ b/exercises/01.exercise-navigation/02.problem.multi-step/README.mdx
@@ -1,6 +1,6 @@
 # Multi-Step Exercise
 
-<EpicVideo url="https://www.epicweb.dev/tutorials/learn-how-to-use-the-epic-workshop-app~kfmou/app-qnd9s/your-first-exercise-step-solution-lypql" />
+<EpicVideo url="https://www.epicweb.dev/tutorials/learn-how-to-use-the-epic-workshop-app~kfmou/app-qnd9s/working-with-multi-step-exercises-problem-679x5" />
 
 👨‍💼 Lots of exercises will have multiple steps. The only thing you need to know
 about this is on each step you need to click the "Set to Playground" button

--- a/exercises/01.exercise-navigation/02.solution.multi-step/README.mdx
+++ b/exercises/01.exercise-navigation/02.solution.multi-step/README.mdx
@@ -1,6 +1,6 @@
 # Multi-Step Exercise
 
-<EpicVideo url="https://www.epicweb.dev/tutorials/learn-how-to-use-the-epic-workshop-app~kfmou/app-qnd9s/your-first-exercise-step-solution-lypql" />
+<EpicVideo url="https://www.epicweb.dev/tutorials/learn-how-to-use-the-epic-workshop-app~kfmou/app-qnd9s/working-with-multi-step-exercises-solution-523p8" />
 
 👨‍💼 Great job on this exercise. There's just one more thing you need to know
 about exercises.

--- a/exercises/01.exercise-navigation/FINISHED.mdx
+++ b/exercises/01.exercise-navigation/FINISHED.mdx
@@ -1,6 +1,6 @@
 # Exercise Navigation
 
-<EpicVideo url="https://www.epicweb.dev/tutorials/learn-how-to-use-the-epic-workshop-app~kfmou/app-qnd9s/working-with-multi-step-exercises-problem-679x5" />
+<EpicVideo url="https://www.epicweb.dev/tutorials/learn-how-to-use-the-epic-workshop-app~kfmou/app-qnd9s/exercise-navigation-wrap-up-l1aqo" />
 
 At the end of each exercise you will see the finished page like this one. This
 will sometimes give you a summary of what you've learned. The primary purpose of

--- a/exercises/02.app-varieties/01.problem.no-preview/README.mdx
+++ b/exercises/02.app-varieties/01.problem.no-preview/README.mdx
@@ -1,6 +1,6 @@
 # No Preview
 
-<EpicVideo url="https://www.epicweb.dev/tutorials/learn-how-to-use-the-epic-workshop-app~kfmou/app-qnd9s/exercise-navigation-wrap-up-l1aqo" />
+<EpicVideo url="https://www.epicweb.dev/tutorials/learn-how-to-use-the-epic-workshop-app~kfmou/app-qnd9s/apps-without-preview-problem-pizqr" />
 
 👨‍💼 Some apps don't have a `dev` script in the `package.json` because they don't
 actually run and you're instead expected to run the app manually.

--- a/exercises/02.app-varieties/01.solution.no-preview/README.mdx
+++ b/exercises/02.app-varieties/01.solution.no-preview/README.mdx
@@ -1,6 +1,6 @@
 # No Preview
 
-<EpicVideo url="https://www.epicweb.dev/tutorials/learn-how-to-use-the-epic-workshop-app~kfmou/app-qnd9s/exercise-navigation-wrap-up-l1aqo" />
+<EpicVideo url="https://www.epicweb.dev/tutorials/learn-how-to-use-the-epic-workshop-app~kfmou/app-qnd9s/apps-without-preview-solution-qlhbc" />
 
 👨‍💼 In some workshops (especially testing workshops) you'll be expected to run
 scripts manually (like you would in practice) which is why there's no preview

--- a/exercises/02.app-varieties/README.mdx
+++ b/exercises/02.app-varieties/README.mdx
@@ -1,6 +1,6 @@
 # App Varieties
 
-<EpicVideo url="https://www.epicweb.dev/tutorials/learn-how-to-use-the-epic-workshop-app~kfmou/app-qnd9s/working-with-multi-step-exercises-solution-523p8" />
+<EpicVideo url="https://www.epicweb.dev/tutorials/learn-how-to-use-the-epic-workshop-app~kfmou/app-qnd9s/introduction-to-app-varieties-15gw0" />
 
 Some workshop have different varieties of apps you work with which change the
 navigation slightly. Let's take a look at those a bit.


### PR DESCRIPTION
This PR fixes the issue #1. I only changed the following steps/pages:

- [x] /exercise/01/01/solution
- [x] /exercise/01/02/problem
- [x] /exercise/01/02/solution
- [x] /exercise/01/finished
- [x] /exercise/02
- [x] /exercise/02/01/problem
- [x] /exercise/02/01/solution

I cannot for the following pages since I do not know the `src` for the following steps/pages:

- [ ] exercise/02/02/problem
- [ ] /exercise/02/02/solution
- [ ] /exercise/02/finished
- [ ] /finished

Please let me know if there are concerns so I can fix. It's my ~first~ second time contributing to open source (the first was a typo) : )