### PR TITLE
fix: epicshop-tutorial referencing incorrect videos

### DIFF
--- a/exercises/01.exercise-navigation/01.solution.first-step/README.mdx
+++ b/exercises/01.exercise-navigation/01.solution.first-step/README.mdx
@@ -1,6 +1,6 @@
 # First Exercise Step
 
-<EpicVideo url="https://www.epicweb.dev/tutorials/learn-how-to-use-the-epic-workshop-app~kfmou/app-qnd9s/your-first-exercise-step-problem-winqy" />
+<EpicVideo url="https://www.epicweb.dev/tutorials/learn-how-to-use-the-epic-workshop-app~kfmou/app-qnd9s/your-first-exercise-step-solution-lypql" />
 
 👨‍💼 Great job! You've made it to the solution portion of the first exercise step!
 On this page, you'll often find a video, diagrams, and code examples, and other

--- a/exercises/01.exercise-navigation/02.problem.multi-step/README.mdx
+++ b/exercises/01.exercise-navigation/02.problem.multi-step/README.mdx
@@ -1,6 +1,6 @@
 # Multi-Step Exercise
 
-<EpicVideo url="https://www.epicweb.dev/tutorials/learn-how-to-use-the-epic-workshop-app~kfmou/app-qnd9s/your-first-exercise-step-solution-lypql" />
+<EpicVideo url="https://www.epicweb.dev/tutorials/learn-how-to-use-the-epic-workshop-app~kfmou/app-qnd9s/working-with-multi-step-exercises-problem-679x5" />
 
 👨‍💼 Lots of exercises will have multiple steps. The only thing you need to know
 about this is on each step you need to click the "Set to Playground" button

--- a/exercises/01.exercise-navigation/02.solution.multi-step/README.mdx
+++ b/exercises/01.exercise-navigation/02.solution.multi-step/README.mdx
@@ -1,6 +1,6 @@
 # Multi-Step Exercise
 
-<EpicVideo url="https://www.epicweb.dev/tutorials/learn-how-to-use-the-epic-workshop-app~kfmou/app-qnd9s/your-first-exercise-step-solution-lypql" />
+<EpicVideo url="https://www.epicweb.dev/tutorials/learn-how-to-use-the-epic-workshop-app~kfmou/app-qnd9s/working-with-multi-step-exercises-solution-523p8" />
 
 👨‍💼 Great job on this exercise. There's just one more thing you need to know
 about exercises.

--- a/exercises/01.exercise-navigation/FINISHED.mdx
+++ b/exercises/01.exercise-navigation/FINISHED.mdx
@@ -1,6 +1,6 @@
 # Exercise Navigation
 
-<EpicVideo url="https://www.epicweb.dev/tutorials/learn-how-to-use-the-epic-workshop-app~kfmou/app-qnd9s/working-with-multi-step-exercises-problem-679x5" />
+<EpicVideo url="https://www.epicweb.dev/tutorials/learn-how-to-use-the-epic-workshop-app~kfmou/app-qnd9s/exercise-navigation-wrap-up-l1aqo" />
 
 At the end of each exercise you will see the finished page like this one. This
 will sometimes give you a summary of what you've learned. The primary purpose of

--- a/exercises/02.app-varieties/01.problem.no-preview/README.mdx
+++ b/exercises/02.app-varieties/01.problem.no-preview/README.mdx
@@ -1,6 +1,6 @@
 # No Preview
 
-<EpicVideo url="https://www.epicweb.dev/tutorials/learn-how-to-use-the-epic-workshop-app~kfmou/app-qnd9s/exercise-navigation-wrap-up-l1aqo" />
+<EpicVideo url="https://www.epicweb.dev/tutorials/learn-how-to-use-the-epic-workshop-app~kfmou/app-qnd9s/apps-without-preview-problem-pizqr" />
 
 👨‍💼 Some apps don't have a `dev` script in the `package.json` because they don't
 actually run and you're instead expected to run the app manually.

--- a/exercises/02.app-varieties/01.solution.no-preview/README.mdx
+++ b/exercises/02.app-varieties/01.solution.no-preview/README.mdx
@@ -1,6 +1,6 @@
 # No Preview
 
-<EpicVideo url="https://www.epicweb.dev/tutorials/learn-how-to-use-the-epic-workshop-app~kfmou/app-qnd9s/exercise-navigation-wrap-up-l1aqo" />
+<EpicVideo url="https://www.epicweb.dev/tutorials/learn-how-to-use-the-epic-workshop-app~kfmou/app-qnd9s/apps-without-preview-solution-qlhbc" />
 
 👨‍💼 In some workshops (especially testing workshops) you'll be expected to run
 scripts manually (like you would in practice) which is why there's no preview

--- a/exercises/02.app-varieties/02.problem.simple/README.mdx
+++ b/exercises/02.app-varieties/02.problem.simple/README.mdx
@@ -1,6 +1,6 @@
 # Simple Apps
 
-<EpicVideo url="https://www.epicweb.dev/tutorials/learn-how-to-use-the-epic-workshop-app~kfmou/app-qnd9s/introduction-to-app-varieties-15gw0" />
+<EpicVideo url="https://www.epicweb.dev/tutorials/learn-how-to-use-the-epic-workshop-app~kfmou/app-qnd9s/simple-apps-without-package-json-problem-2pdau" />
 
 👨‍💼 Some apps are so simple they don't even have a `package.json` file. Instead
 they just have an index file which is automatically opened in the playground.

--- a/exercises/02.app-varieties/02.solution.simple/README.mdx
+++ b/exercises/02.app-varieties/02.solution.simple/README.mdx
@@ -1,6 +1,6 @@
 # Simple Apps
 
-<EpicVideo url="https://www.epicweb.dev/tutorials/learn-how-to-use-the-epic-workshop-app~kfmou/app-qnd9s/introduction-to-app-varieties-15gw0" />
+<EpicVideo url="https://www.epicweb.dev/tutorials/learn-how-to-use-the-epic-workshop-app~kfmou/app-qnd9s/simple-apps-without-package-json-solution-3lvh5" />
 
 👨‍💼 These kinds of apps will automatically refresh when you make changes.
 

--- a/exercises/02.app-varieties/FINISHED.mdx
+++ b/exercises/02.app-varieties/FINISHED.mdx
@@ -1,6 +1,6 @@
 # App Varieties
 
-<EpicVideo url="https://www.epicweb.dev/tutorials/learn-how-to-use-the-epic-workshop-app~kfmou/app-qnd9s/apps-without-preview-problem-pizqr" />
+<EpicVideo url="https://www.epicweb.dev/tutorials/learn-how-to-use-the-epic-workshop-app~kfmou/app-qnd9s/app-varieties-wrap-up-3s1p5" />
 
 Great job. Those are the different types of apps you'll see in Epic workshops.
 

--- a/exercises/02.app-varieties/README.mdx
+++ b/exercises/02.app-varieties/README.mdx
@@ -1,6 +1,6 @@
 # App Varieties
 
-<EpicVideo url="https://www.epicweb.dev/tutorials/learn-how-to-use-the-epic-workshop-app~kfmou/app-qnd9s/working-with-multi-step-exercises-solution-523p8" />
+<EpicVideo url="https://www.epicweb.dev/tutorials/learn-how-to-use-the-epic-workshop-app~kfmou/app-qnd9s/introduction-to-app-varieties-15gw0" />
 
 Some workshop have different varieties of apps you work with which change the
 navigation slightly. Let's take a look at those a bit.

--- a/exercises/FINISHED.mdx
+++ b/exercises/FINISHED.mdx
@@ -1,6 +1,6 @@
 # Epic Workshop App Tutorial 👨‍🏫
 
-<EpicVideo url="https://www.epicweb.dev/tutorials/learn-how-to-use-the-epic-workshop-app~kfmou/app-qnd9s/apps-without-preview-solution-qlhbc" />
+<EpicVideo url="https://www.epicweb.dev/tutorials/learn-how-to-use-the-epic-workshop-app~kfmou/app-qnd9s/congratulations-on-completing-the-workshop-kn79h" />
 
 You've arrived at the end of the workshop! By this time, all the exercises
 should be marked as complete and you're welcome to review any part of the


### PR DESCRIPTION
I got the links from https://www.epicweb.dev/tutorials/learn-how-to-use-the-epic-workshop-app~kfmou